### PR TITLE
Use diameter-synthesis by default

### DIFF
--- a/examples/data/bio_distr.json
+++ b/examples/data/bio_distr.json
@@ -303,6 +303,6 @@
         }
     },
     "diameter": {
-        "method": "default"
+        "method": "no_diameters"
     }
 }

--- a/examples/data/bio_params.json
+++ b/examples/data/bio_params.json
@@ -27,4 +27,4 @@
            0.0,
            0.0],
 "grow_types": ["basal_dendrite", "apical_dendrite"],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "no_diameters"}}

--- a/neurots/extract_input/input_distributions.py
+++ b/neurots/extract_input/input_distributions.py
@@ -29,6 +29,8 @@ from neurots.extract_input.from_TMD import persistent_homology_angles
 from neurots.utils import format_values
 from neurots.utils import neurite_type_warning
 
+from diameter_synthesis.build_models import build as build_diameter_models
+
 L = logging.getLogger(__name__)
 
 
@@ -85,20 +87,25 @@ def distributions(
 
     if diameter_input_morph is None:
         diameter_input_morph = filepath
-
-    if isinstance(diameter_model, str):
-        input_distributions["diameter"] = from_diameter.model(
-            load_morphologies(diameter_input_morph)
-        )
+    morphology = load_morphologies(diameter_input_morph)
+    if isinstance(diameter_model, str) and diameter_model.startswith('M'):
+        input_distributions["diameter"] = from_diameter.model(morphology)
         input_distributions["diameter"]["method"] = diameter_model
 
     elif hasattr(diameter_model, "__call__"):
-        input_distributions["diameter"] = diameter_model(load_morphologies(diameter_input_morph))
+        input_distributions["diameter"] = diameter_model(morphology)
         input_distributions["diameter"]["method"] = "external"
-    else:
+    elif (
+        isinstance(diameter_model, str) and diameter_model == "default"
+    ) or diameter_model is None:
+
         input_distributions["diameter"] = {}
         input_distributions["diameter"]["method"] = "default"
-        L.warning("No valid diameter model provided, so we will not generate a distribution.")
+        input_distributions["diameter"]["diameter"] = build_diameter_models(
+            morphology, config={"models": ["simpler"], "neurite_types": neurite_types}
+        )
+    else:
+        raise NotImplementedError(f"Diameter model {diameter_model} not understood")
 
     for neurite_type in neurite_types:
         if isinstance(feature, str):

--- a/neurots/extract_input/input_distributions.py
+++ b/neurots/extract_input/input_distributions.py
@@ -18,6 +18,7 @@
 import logging
 
 import tmd
+from diameter_synthesis.build_models import build as build_diameter_models
 from neurom import NeuriteType
 from neurom import load_morphologies
 
@@ -28,8 +29,6 @@ from neurots.extract_input.from_neurom import trunk_neurite
 from neurots.extract_input.from_TMD import persistent_homology_angles
 from neurots.utils import format_values
 from neurots.utils import neurite_type_warning
-
-from diameter_synthesis.build_models import build as build_diameter_models
 
 L = logging.getLogger(__name__)
 
@@ -88,7 +87,7 @@ def distributions(
     if diameter_input_morph is None:
         diameter_input_morph = filepath
     morphology = load_morphologies(diameter_input_morph)
-    if isinstance(diameter_model, str) and diameter_model.startswith('M'):
+    if isinstance(diameter_model, str) and diameter_model.startswith("M"):
         input_distributions["diameter"] = from_diameter.model(morphology)
         input_distributions["diameter"]["method"] = diameter_model
 

--- a/neurots/extract_input/input_parameters.py
+++ b/neurots/extract_input/input_parameters.py
@@ -106,6 +106,7 @@ def parameters(
     input_parameters["diameter_params"] = {}
     if diameter_parameters is None:
         input_parameters["diameter_params"]["method"] = "default"
+        input_parameters["diameter_params"]["models"] = ["simpler"]
     elif isinstance(diameter_parameters, str):
         input_parameters["diameter_params"]["method"] = diameter_parameters
     elif isinstance(diameter_parameters, dict):

--- a/neurots/generate/grower.py
+++ b/neurots/generate/grower.py
@@ -198,6 +198,8 @@ class NeuronGrower:
 
     def _post_grow(self):
         """Actions after the morphology has been grown and before its diametrization."""
+        # ensures section.id are consistent with morphio loader
+        self.neuron = Morphology(self.neuron)
 
     def _init_diametrizer(self, external_diametrizer=None):
         """Set a diametrizer function."""

--- a/neurots/generate/grower.py
+++ b/neurots/generate/grower.py
@@ -20,6 +20,7 @@ import json
 import logging
 
 import numpy as np
+from diameter_synthesis import build_diameters
 from morphio.mut import Morphology
 from numpy.random import BitGenerator
 from numpy.random import Generator
@@ -37,8 +38,6 @@ from neurots.morphmath.utils import normalize_vectors
 from neurots.utils import convert_from_legacy_neurite_type
 from neurots.validator import validate_neuron_distribs
 from neurots.validator import validate_neuron_params
-
-from diameter_synthesis import build_diameters
 
 L = logging.getLogger(__name__)
 

--- a/neurots/generate/grower.py
+++ b/neurots/generate/grower.py
@@ -20,7 +20,7 @@ import json
 import logging
 
 import numpy as np
-from morphio.mut import Morphology  # pylint: disable=import-error
+from morphio.mut import Morphology
 from numpy.random import BitGenerator
 from numpy.random import Generator
 from numpy.random import RandomState
@@ -37,6 +37,8 @@ from neurots.morphmath.utils import normalize_vectors
 from neurots.utils import convert_from_legacy_neurite_type
 from neurots.validator import validate_neuron_distribs
 from neurots.validator import validate_neuron_params
+
+from diameter_synthesis import build_diameters
 
 L = logging.getLogger(__name__)
 
@@ -203,14 +205,15 @@ class NeuronGrower:
 
     def _init_diametrizer(self, external_diametrizer=None):
         """Set a diametrizer function."""
-        if self.input_distributions["diameter"]["method"] == "default":
+        if self.input_distributions["diameter"]["method"] == "no_diameters":
             self._diametrize = lambda: None
             L.warning("No diametrizer provided, so neurons will have default diameters.")
         else:
             if self.input_distributions["diameter"]["method"] == "external":
-                if external_diametrizer is None:
-                    raise Exception("Please provide an external diametrizer!")
                 diam_method = external_diametrizer
+            elif self.input_distributions["diameter"]["method"] == "default":
+                self.input_parameters["diameter_params"]["models"] = ["simpler"]
+                diam_method = build_diameters.build
             else:
                 diam_method = self.input_distributions["diameter"]["method"]
 

--- a/neurots/schemas/distributions.json
+++ b/neurots/schemas/distributions.json
@@ -197,7 +197,7 @@
                     "properties": {
                         "method": {
                             "enum": [
-                                "external"
+                                "external", "default"
                             ],
                             "type": "string"
                         }
@@ -209,7 +209,7 @@
                         "method": {
                             "not": {
                                 "enum": [
-                                    "external"
+                                    "external", "default"
                                 ]
                             },
                             "type": "string"

--- a/neurots/schemas/parameters.json
+++ b/neurots/schemas/parameters.json
@@ -246,7 +246,7 @@
                     "properties": {
                         "method": {
                             "enum": [
-                                "external"
+                                "external", "default"
                             ],
                             "description": "The method used to synthesize the diameters",
                             "type": "string"
@@ -260,7 +260,7 @@
                             "description": "The method used to synthesize the diameters",
                             "not": {
                                 "enum": [
-                                    "external"
+                                    "external", "default"
                                 ]
                             },
                             "type": "string"

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ reqs = [
     "numpy>=1.20.0",
     "scipy>=1.6",
     "tmd>=2.2.0",
+    "diameter-synthesis>=0.5.2"
 ]
 
 doc_reqs = [

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ reqs = [
     "numpy>=1.20.0",
     "scipy>=1.6",
     "tmd>=2.2.0",
-    "diameter-synthesis>=0.5.2"
+    "diameter-synthesis>=0.5.2",
 ]
 
 doc_reqs = [

--- a/tests/test_extract_input.py
+++ b/tests/test_extract_input.py
@@ -407,7 +407,7 @@ def test_parameters():
         "axon": {},
         "origin": [0.0, 0.0, 0.0],
         "grow_types": ["basal_dendrite", "apical_dendrite"],
-        "diameter_params": {"method": "default"},
+        "diameter_params": {"method": "default", "models": ["simpler"]},
     }
     assert_equal(params, expected_params)
 
@@ -470,7 +470,7 @@ def test_parameters():
             "axon": {},
             "origin": [0.0, 0.0, 0.0],
             "grow_types": ["basal_dendrite", "apical_dendrite"],
-            "diameter_params": {"method": "default"},
+            "diameter_params": {"method": "default", "models": ["simpler"]},
         },
     )
     validator.validate_neuron_params(params_path)
@@ -496,7 +496,7 @@ def test_parameters():
             },
             "origin": [0.0, 0.0, 0.0],
             "grow_types": ["axon"],
-            "diameter_params": {"method": "default"},
+            "diameter_params": {"method": "default", "models": ["simpler"]},
         },
     )
     validator.validate_neuron_params(params_axon)
@@ -522,7 +522,7 @@ def test_parameters():
             },
             "origin": [0.0, 0.0, 0.0],
             "grow_types": ["axon"],
-            "diameter_params": {"method": "default"},
+            "diameter_params": {"method": "default", "models": ["simpler"]},
         },
     )
     validator.validate_neuron_params(params)

--- a/tests/test_extract_input.py
+++ b/tests/test_extract_input.py
@@ -295,6 +295,14 @@ class TestDistributions:
         )
         validator.validate_neuron_distribs(distr)
 
+    def test_diameter_model_invalid(self, filename):
+        with pytest.raises(NotImplementedError):
+            extract_input.distributions(
+                filename,
+                feature="radial_distances",
+                diameter_model="invalid",
+            )
+
     def test_diameter_model_M5(self, filename):
         distr_M5 = extract_input.distributions(
             filename, feature="radial_distances", diameter_model="M5"

--- a/tests/test_extract_input.py
+++ b/tests/test_extract_input.py
@@ -27,10 +27,13 @@ from neurom import load_morphologies
 from neurom import stats
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_equal
+from pkg_resources import parse_version
 
 from neurots import NeuroTSError
 from neurots import extract_input
 from neurots import validator
+
+_OLD_NUMPY = parse_version(np.__version__) < parse_version("1.21")
 
 _PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "test_data")
 POP_PATH = os.path.join(_PATH, "bio/")
@@ -674,7 +677,7 @@ def test_from_TMD():
     ]
     for a, b in zip(angles["persistence_diagram"], expected):
         for ai, bi in zip(a, b):
-            assert_array_almost_equal(ai, bi)
+            assert_array_almost_equal(ai, bi, decimal=6 if not _OLD_NUMPY else 4)
 
     angles = extract_input.from_TMD.persistent_homology_angles(
         pop, neurite_type="basal_dendrite", threshold=9
@@ -707,4 +710,4 @@ def test_from_TMD():
     ]
     for a, b in zip(angles["persistence_diagram"], expected):
         for ai, bi in zip(a, b):
-            assert_array_almost_equal(ai, bi)
+            assert_array_almost_equal(ai, bi, decimal=6 if not _OLD_NUMPY else 5)

--- a/tests/test_neuron_functional.py
+++ b/tests/test_neuron_functional.py
@@ -289,12 +289,12 @@ def test_breaker_of_tmd_algo():
 
     assert_array_equal(N.apical_sections, [33])
     assert_array_almost_equal(
-        n.sections[169].points[-1],
-        np.array([4.5475516, 46.869442, 49.396336]),
+        n.sections[118].points[-1],
+        np.array([-220.93813, -21.49141, -55.93323]),
         decimal=5,
     )
     assert_array_almost_equal(
-        n.sections[122].points[-1], np.array([-30.22846, 53.705578, -6.5473685]), decimal=5
+        n.sections[30].points[-1], np.array([-17.31787, 151.4876, -6.67741]), decimal=5
     )
 
     # Test with a specific random generator
@@ -305,12 +305,12 @@ def test_breaker_of_tmd_algo():
 
     assert_array_equal(N.apical_sections, [33])
     assert_array_almost_equal(
-        n.sections[169].points[-1],
-        np.array([4.5475516, 46.869442, 49.396336]),
+        n.sections[118].points[-1],
+        np.array([-220.93813, -21.49141, -55.93323]),
         decimal=5,
     )
     assert_array_almost_equal(
-        n.sections[122].points[-1], np.array([-30.22846, 53.705578, -6.5473685]), decimal=5
+        n.sections[30].points[-1], np.array([-17.31787, 151.4876, -6.67741]), decimal=5
     )
 
 

--- a/tests/test_neuron_functional.py
+++ b/tests/test_neuron_functional.py
@@ -206,10 +206,6 @@ def test_external_diametrizer():
     ):
         NeuronGrower(parameters, distributions)
 
-    bad_ng = NeuronGrower(parameters, distributions, external_diametrizer=object())
-    with pytest.raises(Exception, match="Please provide an external diametrizer!"):
-        bad_ng._init_diametrizer()
-
     # Test with an external diametrizer and neurite_types in diameter_params
     distributions["diameter"]["method"] = "external"
     parameters["diameter_params"]["method"] = "external"
@@ -294,11 +290,11 @@ def test_breaker_of_tmd_algo():
     assert_array_equal(N.apical_sections, [33])
     assert_array_almost_equal(
         n.sections[169].points[-1],
-        np.array([-220.93813, -21.49141, -55.93323]),
+        np.array([4.5475516, 46.869442, 49.396336]),
         decimal=5,
     )
     assert_array_almost_equal(
-        n.sections[122].points[-1], np.array([-17.31787, 151.4876, -6.67741]), decimal=5
+        n.sections[122].points[-1], np.array([-30.22846, 53.705578, -6.5473685]), decimal=5
     )
 
     # Test with a specific random generator
@@ -310,11 +306,11 @@ def test_breaker_of_tmd_algo():
     assert_array_equal(N.apical_sections, [33])
     assert_array_almost_equal(
         n.sections[169].points[-1],
-        np.array([-220.93813, -21.49141, -55.93323]),
+        np.array([4.5475516, 46.869442, 49.396336]),
         decimal=5,
     )
     assert_array_almost_equal(
-        n.sections[122].points[-1], np.array([-17.31787, 151.4876, -6.67741]), decimal=5
+        n.sections[122].points[-1], np.array([-30.22846, 53.705578, -6.5473685]), decimal=5
     )
 
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -69,14 +69,6 @@ class TestValidateParams:
         dummy_params["diameter_params"] = {"method": "default"}
         tested.validate_neuron_params(dummy_params)
 
-    def test_default_diameter_unknown_key(self, dummy_params):
-        dummy_params["diameter_params"] = {
-            "method": "default",
-            "other key": "any value",
-        }
-        with pytest.raises(tested.ValidationError):
-            tested.validate_neuron_params(dummy_params)
-
     def test_M1_diameter_unknown_key(self, dummy_params):
         dummy_params["diameter_params"] = {"method": "M1", "other key": "any value"}
         with pytest.raises(tested.ValidationError):


### PR DESCRIPTION
- Use diameter-synthesis latest algo as default instead of no diametrizer.
- To use no_diametrizer, specify 'no_diameters' instead of 'default'.
- We apply a post_growth operation of relabeling morphio section.id for easier use with external diametrizer, as any reloading to neurom for example will break the section.id mappings and will not allow one to easily change diamters of morphio object in place