### PR TITLE
Add context handling with accept/reject

### DIFF
--- a/neurots/generate/grower.py
+++ b/neurots/generate/grower.py
@@ -92,7 +92,6 @@ class NeuronGrower:
         """Constructor of the NeuronGrower class."""
         self.neuron = Morphology()
         self.context = context
-        print('-------', context)
         if rng_or_seed is None or isinstance(
             rng_or_seed, (int, np.integer, SeedSequence, BitGenerator)
         ):

--- a/neurots/generate/grower.py
+++ b/neurots/generate/grower.py
@@ -92,6 +92,7 @@ class NeuronGrower:
         """Constructor of the NeuronGrower class."""
         self.neuron = Morphology()
         self.context = context
+        print('-------', context)
         if rng_or_seed is None or isinstance(
             rng_or_seed, (int, np.integer, SeedSequence, BitGenerator)
         ):

--- a/neurots/generate/orientations.py
+++ b/neurots/generate/orientations.py
@@ -18,6 +18,7 @@ from neurots.morphmath import sample
 from neurots.morphmath.utils import normalize_vectors
 from neurots.utils import PIA_DIRECTION
 from neurots.utils import NeuroTSError
+from neurots.utils import accept_reject
 
 _TWOPI = 2.0 * np.pi
 FIT_3D_ANGLES_BOUNDS = {
@@ -256,13 +257,13 @@ class OrientationManager(OrientationManagerBase):
     def _mode_pia_constraint(self, _, tree_type):
         """Create trunks from distribution of angles with pia (`[0 , 1, 0]`) direction.
 
-        See :func:`_sample_trunk_from_3d_angle` for more details on the algorithm.
+        See :func:`self._sample_trunk_from_3d_angle` for more details on the algorithm.
         """
         n_orientations = sample.n_neurites(self._distributions[tree_type]["num_trees"], self._rng)
         pia_direction = self._parameters.get("pia_direction", PIA_DIRECTION)
         return np.asarray(
             [
-                _sample_trunk_from_3d_angle(self._parameters, self._rng, tree_type, pia_direction)
+                self._sample_trunk_from_3d_angle(tree_type, pia_direction)
                 for _ in range(n_orientations)
             ]
         )
@@ -270,16 +271,39 @@ class OrientationManager(OrientationManagerBase):
     def _mode_apical_constraint(self, _, tree_type):
         """Create trunks from distribution of angles with apical direction.
 
-        See :func:`_sample_trunk_from_3d_angle` for more details on the algorithm.
+        See :func:`self._sample_trunk_from_3d_angle` for more details on the algorithm.
         """
         n_orientations = sample.n_neurites(self._distributions[tree_type]["num_trees"], self._rng)
         ref_dir = self._orientations["apical_dendrite"][0]
         return np.asarray(
-            [
-                _sample_trunk_from_3d_angle(self._parameters, self._rng, tree_type, ref_dir)
-                for _ in range(n_orientations)
-            ]
+            [self._sample_trunk_from_3d_angle(tree_type, ref_dir) for _ in range(n_orientations)]
         )
+
+    def _sample_trunk_from_3d_angle(self, tree_type, ref_dir, max_tries=100):
+        """Sample trunk directions from fit of distribution of `3d_angles` wrt to `ref_dir`.
+
+        We use the accept-reject algorithm so we can sample from any distribution.
+        After a number of unsuccessful tries (default=100), we stop and return a random direction.
+        We also issue a warning so the user is aware that the provided distribution may have issues,
+        mostly related to large region of small probabilities.
+        """
+
+        def propose():
+            return sample.sample_spherical_unit_vectors(self._rng)
+
+        def prob(proposal):
+            val = nm.morphmath.angle_between_vectors(ref_dir, proposal)
+            _prob = get_probability_function(
+                form=self._parameters[tree_type]["orientation"]["values"]["form"],
+                with_density=False,
+            )
+            params = self._parameters[tree_type]["orientation"]["values"]["params"]
+            return _prob(val, *params)
+
+        def null():
+            return sample.sample_spherical_unit_vectors(self._rng)
+
+        return accept_reject(propose, prob, self._rng, null=null, max_tries=max_tries)
 
 
 def spherical_angles_to_orientations(phis, thetas):
@@ -631,30 +655,3 @@ def fit_3d_angles(tmd_parameters, tmd_distributions):
             )
 
     return tmd_parameters
-
-
-def _sample_trunk_from_3d_angle(parameters, rng, tree_type, ref_dir, max_tries=100):
-    """Sample trunk directions from fit of distribution of `3d_angles` wrt to `ref_dir`.
-
-    We use the accept-reject algorithm so we can sample from any distribution.
-    After a number of unsuccessful tries (default=100), we stop and return a random direction.
-    We also issue a warning so the user is aware that the provided distribution may have issues,
-    mostly related to large region of small probabilities.
-    """
-    prob = get_probability_function(
-        form=parameters[tree_type]["orientation"]["values"]["form"],
-        with_density=False,
-    )
-    params = parameters[tree_type]["orientation"]["values"]["params"]
-    n_try = 0
-    while n_try < max_tries:
-        propose = sample.sample_spherical_unit_vectors(rng)
-        angle = nm.morphmath.angle_between_vectors(ref_dir, propose)
-        if rng.binomial(1, prob(angle, *params)):
-            return propose
-        n_try += 1
-    warnings.warn(
-        """We could not sample from distribution, so we take a random point.
-                    Consider checking the given probability distribution."""
-    )
-    return sample.sample_spherical_unit_vectors(rng)

--- a/neurots/generate/orientations.py
+++ b/neurots/generate/orientations.py
@@ -310,13 +310,7 @@ class OrientationManager(OrientationManagerBase):
                         p *= constraint["trunk_prob"](proposal, self._soma.center)
             return p
 
-        def default_propose():
-            """Trunk angle returned if we cannot accept one after `max_tries`."""
-            return sample.sample_spherical_unit_vectors(self._rng)
-
-        return accept_reject(
-            propose, prob, self._rng, default_propose=default_propose, max_tries=max_tries
-        )
+        return accept_reject(propose, prob, self._rng, max_tries=max_tries)
 
 
 def spherical_angles_to_orientations(phis, thetas):

--- a/neurots/generate/orientations.py
+++ b/neurots/generate/orientations.py
@@ -289,18 +289,24 @@ class OrientationManager(OrientationManagerBase):
         """
 
         def propose():
+            """Propose a trunk angle."""
             return sample.sample_spherical_unit_vectors(self._rng)
 
         def prob(proposal):
+            """Probability function to accept a trunk angle."""
             val = nm.morphmath.angle_between_vectors(ref_dir, proposal)
             _prob = get_probability_function(
                 form=self._parameters[tree_type]["orientation"]["values"]["form"],
                 with_density=False,
             )
             params = self._parameters[tree_type]["orientation"]["values"]["params"]
-            return _prob(val, *params)
+            p = _prob(val, *params)
+            if "trunk_prob" in self._context:  # pragma: no cover
+                p *= self._context["trunk_prob"](proposal)
+            return p
 
         def null():
+            """Trunk angle returned if we cannot accept one after `max_tries`."""
             return sample.sample_spherical_unit_vectors(self._rng)
 
         return accept_reject(propose, prob, self._rng, null=null, max_tries=max_tries)

--- a/neurots/generate/orientations.py
+++ b/neurots/generate/orientations.py
@@ -301,8 +301,13 @@ class OrientationManager(OrientationManagerBase):
             )
             params = self._parameters[tree_type]["orientation"]["values"]["params"]
             p = _prob(val, *params)
-            if self._context is not None and "trunk_prob" in self._context:  # pragma: no cover
-                p *= self._context["trunk_prob"](proposal, self._soma.center)
+
+            if self._context is not None and self._context.get(
+                "constraints", []
+            ):  # pragma: no cover
+                for constraint in self._context["constraints"]:
+                    if "trunk_prob" in constraint:
+                        p *= constraint["trunk_prob"](proposal, self._soma.center)
             return p
 
         def default_propose():

--- a/neurots/generate/orientations.py
+++ b/neurots/generate/orientations.py
@@ -305,11 +305,13 @@ class OrientationManager(OrientationManagerBase):
                 p *= self._context["trunk_prob"](proposal, self._soma.center)
             return p
 
-        def null():
+        def default_propose():
             """Trunk angle returned if we cannot accept one after `max_tries`."""
             return sample.sample_spherical_unit_vectors(self._rng)
 
-        return accept_reject(propose, prob, self._rng, null=null, max_tries=max_tries)
+        return accept_reject(
+            propose, prob, self._rng, default_propose=default_propose, max_tries=max_tries
+        )
 
 
 def spherical_angles_to_orientations(phis, thetas):

--- a/neurots/generate/orientations.py
+++ b/neurots/generate/orientations.py
@@ -288,7 +288,7 @@ class OrientationManager(OrientationManagerBase):
         mostly related to large region of small probabilities.
         """
 
-        def propose():
+        def propose(_):
             """Propose a trunk angle."""
             return sample.sample_spherical_unit_vectors(self._rng)
 

--- a/neurots/generate/orientations.py
+++ b/neurots/generate/orientations.py
@@ -302,7 +302,7 @@ class OrientationManager(OrientationManagerBase):
             params = self._parameters[tree_type]["orientation"]["values"]["params"]
             p = _prob(val, *params)
             if self._context is not None and "trunk_prob" in self._context:  # pragma: no cover
-                p *= self._context["trunk_prob"](proposal)
+                p *= self._context["trunk_prob"](proposal, self._soma.center)
             return p
 
         def null():

--- a/neurots/generate/orientations.py
+++ b/neurots/generate/orientations.py
@@ -301,7 +301,7 @@ class OrientationManager(OrientationManagerBase):
             )
             params = self._parameters[tree_type]["orientation"]["values"]["params"]
             p = _prob(val, *params)
-            if "trunk_prob" in self._context:  # pragma: no cover
+            if self._context is not None and "trunk_prob" in self._context:  # pragma: no cover
                 p *= self._context["trunk_prob"](proposal)
             return p
 

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -102,7 +102,7 @@ class SectionGrower:
     def next_point(self, current_point):
         """Returns the next point depending on the growth method and the previous point.
 
-        If a context is present, an accept-reject mechanisms will be used to alter the next point.
+        If a context is present, an accept-reject mechanism will be used to alter the next point.
         """
         if self.context is not None and "constraints" in self.context:  # pragma: no cover
 

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -104,7 +104,7 @@ class SectionGrower:
 
         If a context is present, an accept-reject mechanism will be used to alter the next point.
         """
-        if self.context is not None and "constraints" in self.context:  # pragma: no cover
+        if self.context is not None and self.context.get("constraints", []):  # pragma: no cover
 
             def prob(*args, **kwargs):
                 p = 1.0

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -108,7 +108,7 @@ class SectionGrower:
 
             def prob(*args, **kwargs):
                 p = 1.0
-                for i, constraint in enumerate(self.context["constraints"]):
+                for constraint in self.context["constraints"]:
                     p *= constraint["section_prob"](*args, **kwargs)
                 return p
 

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -84,7 +84,7 @@ class SectionGrower:
     def next_point(self, current_point):
         """Returns the next point depending on the growth method and the previous point."""
 
-        def prob(proposal):
+        def prob(_):
             return 1.0
 
         def propose():

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -84,10 +84,17 @@ class SectionGrower:
     def next_point(self, current_point):
         """Returns the next point depending on the growth method and the previous point."""
 
-        def prob(_):
+        def prob(data):
+            """Probability function to accept a next point.
+
+            It will always accept unless a context prob function is present.
+            """
+            if "section_prob" in self.context:  # pragma: no cover
+                return self.context["section_prob"](data)
             return 1.0
 
         def propose():
+            """Propose a next section point."""
             direction = (
                 self.params.targeting * self.direction
                 + self.params.randomness * get_random_point(random_generator=self._rng)

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -89,7 +89,7 @@ class SectionGrower:
         """Propose the direction for a next section point.
 
         Args:
-            extra_randomness (float): artificially increase the randomness to allow for context changes
+            extra_randomness (float): artificially increase the randomness to allow for context
         """
         direction = self.params.targeting * self.direction + self.params.history * self.history()
         if extra_randomness > -1:
@@ -107,7 +107,7 @@ class SectionGrower:
         If a context is present, an accept-reject mechanism will be used to alter the next point.
 
         Args:
-            extra_randomness (float): only used without constraints, if -1.0, no randomness is applied
+            extra_randomness (float): only used without constraints if -1.0 no randomness is applied
         """
         if self.context is not None and self.context.get("constraints", []):  # pragma: no cover
 

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -104,19 +104,32 @@ class SectionGrower:
 
         If a context is present, an accept-reject mechanisms will be used to alter the next point.
         """
-        if self.context is not None and "section_prob" in self.context:  # pragma: no cover
-            direction = accept_reject(
-                self._propose,
-                self.context["section_prob"],
-                self._rng,
-                max_tries=self.context.get("params_section", {}).get(
-                    "max_tries", DEFAULT_MAX_TRIES
-                ),
-                noise_increase=self.context.get("params_section", {}).get(
-                    "noise_increase", DEFAULT_NOISE_INCREASE
-                ),
-                current_point=current_point,
-            )
+        if self.context is not None and "boundaries" in self.context:  # pragma: no cover
+            for boundary in self.context["boundaries"]:
+                # we only consider boundary for certain neurite types
+                neurite_types = boundary.get("neurite_types", None)
+                if (
+                    self.parent is not None
+                    and neurite_types is not None
+                    and self.parent.type.name not in neurite_types
+                ):
+                    direction = self._propose()
+
+                elif "section_prob" in boundary:
+                    direction = accept_reject(
+                        self._propose,
+                        boundary["section_prob"],
+                        self._rng,
+                        max_tries=boundary.get("params_section", {}).get(
+                            "max_tries", DEFAULT_MAX_TRIES
+                        ),
+                        noise_increase=boundary.get("params_section", {}).get(
+                            "noise_increase", DEFAULT_NOISE_INCREASE
+                        ),
+                        current_point=current_point,
+                    )
+                else:
+                    direction = self._propose()
         else:
             direction = self._propose()
 

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import deque
-
+from functools import partial
 import numpy as np
 from numpy.linalg import norm as vectorial_norm  # vectorial_norm used for array of vectors
 
@@ -85,7 +85,7 @@ class SectionGrower:
         """Increases the path distance."""
         self.pathlength += length
 
-    def _propose(self, extra_randomness=None, add_random_component=True):
+    def _propose(self, extra_randomness=0, add_random_component=True):
         """Propose the direction for a next section point.
 
         Args:
@@ -96,13 +96,13 @@ class SectionGrower:
 
         if add_random_component:
             random_component = self.params.randomness * get_random_point(random_generator=self._rng)
-            if extra_randomness is not None:
+            if extra_randomness > 0:
                 random_component *= extra_randomness
             direction += random_component
 
         return direction / vectorial_norm(direction)
 
-    def next_point(self, add_random_component=True, extra_randomness=None):
+    def next_point(self, add_random_component=True, extra_randomness=0):
         """Returns the next point depending on the growth method and the previous point.
 
         If a context is present, an accept-reject mechanism will be used to alter the next point.
@@ -138,7 +138,10 @@ class SectionGrower:
                 randomness_increase = DEFAULT_RANDOMNESS_INCREASE
 
             direction = accept_reject(
-                self._propose,
+                partial(
+                    self._propose,
+                    add_random_component=add_random_component,
+                ),
                 prob,
                 self._rng,
                 max_tries=max_tries,

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -89,7 +89,7 @@ class SectionGrower:
 
             It will always accept unless a context prob function is present.
             """
-            if "section_prob" in self.context:  # pragma: no cover
+            if self.context is not None and "section_prob" in self.context:  # pragma: no cover
                 return self.context["section_prob"](data)
             return 1.0
 

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -113,8 +113,12 @@ class SectionGrower:
             propose,
             prob,
             self._rng,
-            self.context.get("params_section", {}).get("max_tries", 100),
-            self.context.get("params_section", {}).get("noise_increase", 0.5),
+            self.context.get("params_section", {}).get("max_tries", 100)
+            if self.context is not None
+            else 100,
+            self.context.get("params_section", {}).get("noise_increase", 0.5)
+            if self.context is not None
+            else 0.5,
         )
         seg_length = self.step_size_distribution.draw_positive()
         next_point = current_point + seg_length * direction

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -142,7 +142,6 @@ class SectionGrower:
                 prob,
                 self._rng,
                 max_tries=max_tries,
-                add_random_component=add_random_component,
                 randomness_increase=randomness_increase,
                 current_point=self.last_point,
             )

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -109,14 +109,12 @@ class SectionGrower:
                 self._propose,
                 self.context["section_prob"],
                 self._rng,
-                max_tries=self.context.get("params_section", {}).get("max_tries", DEFAULT_MAX_TRIES)
-                if self.context is not None
-                else DEFAULT_MAX_TRIES,
+                max_tries=self.context.get("params_section", {}).get(
+                    "max_tries", DEFAULT_MAX_TRIES
+                ),
                 noise_increase=self.context.get("params_section", {}).get(
                     "noise_increase", DEFAULT_NOISE_INCREASE
-                )
-                if self.context is not None
-                else DEFAULT_NOISE_INCREASE,
+                ),
                 current_point=current_point,
             )
         else:

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -117,8 +117,8 @@ class SectionGrower:
                     p *= constraint["section_prob"](*args, **kwargs)
                 return p
 
-            max_tries = DEFAULT_MAX_TRIES
-            randomness_increase = DEFAULT_RANDOMNESS_INCREASE
+            max_tries = -1
+            randomness_increase = -1
             for constraint in self.context["constraints"]:
                 max_tries = max(
                     max_tries,
@@ -130,6 +130,10 @@ class SectionGrower:
                         "randomness_increase", DEFAULT_RANDOMNESS_INCREASE
                     ),
                 )
+            if max_tries < 0:
+                max_tries = DEFAULT_MAX_TRIES
+            if randomness_increase < 0:
+                randomness_increase = DEFAULT_RANDOMNESS_INCREASE
 
             direction = accept_reject(
                 self._propose,

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -109,7 +109,13 @@ class SectionGrower:
 
             return direction / vectorial_norm(direction)
 
-        direction = accept_reject(propose, prob, self._rng)
+        direction = accept_reject(
+            propose,
+            prob,
+            self._rng,
+            self.context.get("params_section", {}).get("max_tries", 100),
+            self.context.get("params_section", {}).get("noise_increase", 0.5),
+        )
         seg_length = self.step_size_distribution.draw_positive()
         next_point = current_point + seg_length * direction
         self.update_pathlength(seg_length)

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -95,23 +95,21 @@ class SectionGrower:
         direction = self.params.targeting * self.direction + self.params.history * self.history()
 
         if add_random_component:
-            random_component =  (
-                    self.params.randomness
-                    * get_random_point(random_generator=self._rng)
-                )
+            random_component = self.params.randomness * get_random_point(random_generator=self._rng)
             if extra_randomness is not None:
                 random_component *= extra_randomness
             direction += random_component
 
         return direction / vectorial_norm(direction)
 
-    def next_point(self, extra_randomness=0):
+    def next_point(self, add_random_component=True, extra_randomness=None):
         """Returns the next point depending on the growth method and the previous point.
 
         If a context is present, an accept-reject mechanism will be used to alter the next point.
 
         Args:
-            extra_randomness (float): only used without constraints if -1.0 no randomness is applied
+            add_random_component (bool): add a random component to the direction
+            extra_randomness (float): only used without constraints
         """
         if self.context is not None and self.context.get("constraints", []):  # pragma: no cover
 
@@ -144,11 +142,14 @@ class SectionGrower:
                 prob,
                 self._rng,
                 max_tries=max_tries,
+                add_random_component=add_random_component,
                 randomness_increase=randomness_increase,
                 current_point=self.last_point,
             )
         else:
-            direction = self._propose(extra_randomness)
+            direction = self._propose(
+                add_random_component=add_random_component, extra_randomness=extra_randomness
+            )
 
         seg_length = self.step_size_distribution.draw_positive()
         next_point = self.last_point + seg_length * direction
@@ -168,7 +169,7 @@ class SectionGrower:
             The growth process cannot terminate before this point, as a first point will always be
             added to an active section.
         """
-        self.next_point(extra_randomness=-1.0)
+        self.next_point(add_random_component=False)
 
     def check_stop(self):
         """Checks if any num_seg criteria is fulfilled.

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -85,19 +85,23 @@ class SectionGrower:
         """Increases the path distance."""
         self.pathlength += length
 
-    def _propose(self, extra_randomness=0.0):
+    def _propose(self, extra_randomness=None, add_random_component=True):
         """Propose the direction for a next section point.
 
         Args:
             extra_randomness (float): artificially increase the randomness to allow for context
+            add_random_component (bool): add a random component to the direction
         """
         direction = self.params.targeting * self.direction + self.params.history * self.history()
-        if extra_randomness > -1:
-            direction += (
-                self.params.randomness
-                * get_random_point(random_generator=self._rng)
-                * (1.0 + extra_randomness)
-            )
+
+        if add_random_component:
+            random_component =  (
+                    self.params.randomness
+                    * get_random_point(random_generator=self._rng)
+                )
+            if extra_randomness is not None:
+                random_component *= extra_randomness
+            direction += random_component
 
         return direction / vectorial_norm(direction)
 

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -113,10 +113,10 @@ class SectionGrower:
             propose,
             prob,
             self._rng,
-            self.context.get("params_section", {}).get("max_tries", 100)
+            max_tries=self.context.get("params_section", {}).get("max_tries", 100)
             if self.context is not None
             else 100,
-            self.context.get("params_section", {}).get("noise_increase", 0.5)
+            noise_increase=self.context.get("params_section", {}).get("noise_increase", 0.5)
             if self.context is not None
             else 0.5,
         )

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -6,6 +6,7 @@
 
 from collections import deque
 from functools import partial
+
 import numpy as np
 from numpy.linalg import norm as vectorial_norm  # vectorial_norm used for array of vectors
 

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -97,7 +97,7 @@ class SectionGrower:
 
         if add_random_component:
             random_component = self.params.randomness * get_random_point(random_generator=self._rng)
-            if extra_randomness > 0:
+            if extra_randomness > 0:  # pragma: no cover
                 random_component *= extra_randomness
             direction += random_component
 

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -20,7 +20,7 @@ DISTANCE_MIN = 1e-8
 WEIGHTS = np.exp(np.arange(1, MEMORY + 1) - MEMORY)
 
 # default parameters for accept/reject
-DEFAULT_MAX_TRIES = 100
+DEFAULT_MAX_TRIES = 50
 DEFAULT_RANDOMNESS_INCREASE = 0.5
 
 

--- a/neurots/generate/tree.py
+++ b/neurots/generate/tree.py
@@ -166,7 +166,7 @@ class TreeGrower:
         SGrower = section_growers[self.params["metric"]]
         context = copy.deepcopy(self.context)
         if self.context is not None and "constraints" in self.context:  # pragma: no cover
-            constraints = [
+            context["constraints"] = [
                 constraint
                 for constraint in self.context["constraints"]
                 if "section_prob" in constraint
@@ -174,10 +174,6 @@ class TreeGrower:
                 in constraint.get("neurite_types", [])
                 and process in constraint.get("processes", ["major", "secondary"])
             ]
-            if constraints:
-                context["constraints"] = constraints
-            else:
-                del context["constraints"]
 
         sec_grower = SGrower(
             parent=parent,

--- a/neurots/generate/tree.py
+++ b/neurots/generate/tree.py
@@ -164,7 +164,6 @@ class TreeGrower:
             children (int): The number of children.
         """
         SGrower = section_growers[self.params["metric"]]
-
         sec_grower = SGrower(
             parent=parent,
             first_point=first_point,

--- a/neurots/generate/tree.py
+++ b/neurots/generate/tree.py
@@ -164,6 +164,21 @@ class TreeGrower:
             children (int): The number of children.
         """
         SGrower = section_growers[self.params["metric"]]
+        context = copy.deepcopy(self.context)
+        if self.context is not None and "constraints" in self.context:  # pragma: no cover
+            constraints = [
+                constraint
+                for constraint in self.context["constraints"]
+                if "section_prob" in constraint
+                and SectionType(self.params["tree_type"]).name
+                in constraint.get("neurite_types", [])
+                and process in constraint.get("processes", ["major", "secondary"])
+            ]
+            if constraints:
+                context["constraints"] = constraints
+            else:
+                del context["constraints"]
+
         sec_grower = SGrower(
             parent=parent,
             first_point=first_point,
@@ -174,7 +189,7 @@ class TreeGrower:
             stop_criteria=copy.deepcopy(stop),
             step_size_distribution=self.seg_length_distr,
             pathlength=pathlength,
-            context=self.context,
+            context=context,
             random_generator=self._rng,
         )
 

--- a/neurots/utils.py
+++ b/neurots/utils.py
@@ -100,7 +100,7 @@ def point_to_section_segment(neuron, point, rtol=1e-05, atol=1e-08):
 def accept_reject(
     propose, probability, rng, null=None, max_tries=100, noise_increase=0.5, **probability_kwargs
 ):
-    """Generic accept reject algorithm."""
+    """Generic accept/reject algorithm."""
     n_tries = 0
     while n_tries < max_tries:
         proposal = propose(n_tries * noise_increase)

--- a/neurots/utils.py
+++ b/neurots/utils.py
@@ -110,8 +110,8 @@ def accept_reject(
     Args:
         propose (callable): function to propose a move, which has an 'noise' argument to allow
             for increasing randomness and faster acceptance (to allow sharp turns, etc...)
-        probability (callable): function to compute probability, first arg is the poposal (output of
-            `propose` function), and takes extra kwargs via `probability_kwargs`
+        probability (callable): function to compute probability, first arg is the proposal (output
+             of `propose` function), and takes extra kwargs via `probability_kwargs`
         rng (np.random._generator.Generator): random number generator
         max_tries (int): maximum number of tries to accept before we return best proposal
         randomness_increase (float): increase of noise amplitude after each try

--- a/neurots/utils.py
+++ b/neurots/utils.py
@@ -105,7 +105,6 @@ def accept_reject(
     while n_tries < max_tries:
         proposal = propose(n_tries * noise_increase)
         _prob = probability(proposal, **probability_kwargs)
-
         if _prob == 1.0:
             # this ensures we don't change rng for the tests, but its not really needed
             return proposal

--- a/neurots/utils.py
+++ b/neurots/utils.py
@@ -120,7 +120,7 @@ def accept_reject(
     """
     n_tries = 0
     best_proposal = None
-    best_p = 0
+    best_p = -1.0
     while n_tries < max_tries:
         proposal = propose(n_tries * randomness_increase)
         _prob = probability(proposal, **probability_kwargs)
@@ -130,9 +130,11 @@ def accept_reject(
 
         if rng.binomial(1, _prob):
             return proposal
+
         if _prob > best_p:
             best_p = _prob
             best_proposal = proposal
+
         n_tries += 1
     warnings.warn("We could not sample from distribution, we take best sample.")
     return best_proposal

--- a/neurots/utils.py
+++ b/neurots/utils.py
@@ -97,7 +97,7 @@ def point_to_section_segment(neuron, point, rtol=1e-05, atol=1e-08):
     raise ValueError(f"Cannot find point in morphology that matches: {point}")
 
 
-def accept_reject(propose, prob, rng, null=None, max_tries=100, noise_increase=0.2):
+def accept_reject(propose, prob, rng, null=None, max_tries=100, noise_increase=0.5):
     """Generic accept reject algorithm."""
     n_try = 0
     while n_try < max_tries:

--- a/neurots/utils.py
+++ b/neurots/utils.py
@@ -95,3 +95,26 @@ def point_to_section_segment(neuron, point, rtol=1e-05, atol=1e-08):
             return section.id, offset[0][0]
 
     raise ValueError(f"Cannot find point in morphology that matches: {point}")
+
+
+def accept_reject(propose, prob, rng, null=None, max_tries=100):
+    """Generic accept reject algorithm."""
+    n_try = 0
+    while n_try < max_tries:
+        proposal = propose()
+        _prob = prob(proposal)
+
+        if _prob == 1.0:
+            # this ensures we don't change rng for the tests, but its not really needed
+            return proposal
+
+        if rng.binomial(1, _prob):
+            return proposal
+        n_try += 1
+    warnings.warn(
+        """We could not sample from distribution, so we take a random point.
+                    Consider checking the given probability distribution."""
+    )
+    if null is not None:
+        return null()
+    return proposal

--- a/neurots/utils.py
+++ b/neurots/utils.py
@@ -98,9 +98,29 @@ def point_to_section_segment(neuron, point, rtol=1e-05, atol=1e-08):
 
 
 def accept_reject(
-    propose, probability, rng, null=None, max_tries=100, noise_increase=0.5, **probability_kwargs
+    propose,
+    probability,
+    rng,
+    default_propose=None,
+    max_tries=100,
+    noise_increase=0.5,
+    **probability_kwargs,
 ):
-    """Generic accept/reject algorithm."""
+    """Generic accept/reject algorithm.
+
+    Args:
+        propose (callable): function to propose a move, which has an 'noise' argument to allow
+            for increasing randomness and faster acceptance (to allow sharp turns, etc...)
+        probability (callable): function to compute probability, first arg is the poposal (output of
+            `propose` function), and takes extra kwargs via `probability_kwargs`
+        rng (np.random._generator.Generator): random number generator
+        default_propose (callable): function to use if we cannot accept a proposal,
+            if None, propose is used
+        max_tries (int): maximum number of tries to accept before `default_propose` is called
+        noise_increase (float): increase of noise amplitude after each try
+        probability_kwargs (dict): parameters for `probability` function
+
+    """
     n_tries = 0
     while n_tries < max_tries:
         proposal = propose(n_tries * noise_increase)
@@ -113,9 +133,9 @@ def accept_reject(
             return proposal
         n_tries += 1
     warnings.warn(
-        "We could not sample from distribution, so we take a random point. "
-        "Consider checking the given probability distribution."
+        "We could not sample from distribution, we take a random point unless a 'default_propose' "
+        "function is provided. Consider checking the given probability distribution."
     )
-    if null is not None:
-        return null()
+    if default_propose is not None:
+        return default_propose()
     return proposal

--- a/neurots/utils.py
+++ b/neurots/utils.py
@@ -99,9 +99,9 @@ def point_to_section_segment(neuron, point, rtol=1e-05, atol=1e-08):
 
 def accept_reject(propose, prob, rng, null=None, max_tries=100, noise_increase=0.5):
     """Generic accept reject algorithm."""
-    n_try = 0
-    while n_try < max_tries:
-        proposal = propose(n_try * noise_increase)
+    n_tries = 0
+    while n_tries < max_tries:
+        proposal = propose(n_tries * noise_increase)
         _prob = prob(proposal)
 
         if _prob == 1.0:
@@ -110,7 +110,7 @@ def accept_reject(propose, prob, rng, null=None, max_tries=100, noise_increase=0
 
         if rng.binomial(1, _prob):
             return proposal
-        n_try += 1
+        n_tries += 1
     warnings.warn(
         "We could not sample from distribution, so we take a random point. "
         "Consider checking the given probability distribution."

--- a/neurots/utils.py
+++ b/neurots/utils.py
@@ -97,12 +97,14 @@ def point_to_section_segment(neuron, point, rtol=1e-05, atol=1e-08):
     raise ValueError(f"Cannot find point in morphology that matches: {point}")
 
 
-def accept_reject(propose, prob, rng, null=None, max_tries=100, noise_increase=0.5):
+def accept_reject(
+    propose, probability, rng, null=None, max_tries=100, noise_increase=0.5, **probability_kwargs
+):
     """Generic accept reject algorithm."""
     n_tries = 0
     while n_tries < max_tries:
         proposal = propose(n_tries * noise_increase)
-        _prob = prob(proposal)
+        _prob = probability(proposal, **probability_kwargs)
 
         if _prob == 1.0:
             # this ensures we don't change rng for the tests, but its not really needed

--- a/neurots/utils.py
+++ b/neurots/utils.py
@@ -112,8 +112,8 @@ def accept_reject(propose, prob, rng, null=None, max_tries=100):
             return proposal
         n_try += 1
     warnings.warn(
-        """We could not sample from distribution, so we take a random point.
-                    Consider checking the given probability distribution."""
+        "We could not sample from distribution, so we take a random point. "
+        "Consider checking the given probability distribution."
     )
     if null is not None:
         return null()

--- a/neurots/utils.py
+++ b/neurots/utils.py
@@ -103,7 +103,7 @@ def accept_reject(
     rng,
     default_propose=None,
     max_tries=100,
-    noise_increase=0.5,
+    randomness_increase=0.5,
     **probability_kwargs,
 ):
     """Generic accept/reject algorithm.
@@ -117,13 +117,13 @@ def accept_reject(
         default_propose (callable): function to use if we cannot accept a proposal,
             if None, propose is used
         max_tries (int): maximum number of tries to accept before `default_propose` is called
-        noise_increase (float): increase of noise amplitude after each try
+        randomness_increase (float): increase of noise amplitude after each try
         probability_kwargs (dict): parameters for `probability` function
 
     """
     n_tries = 0
     while n_tries < max_tries:
-        proposal = propose(n_tries * noise_increase)
+        proposal = propose(n_tries * randomness_increase)
         _prob = probability(proposal, **probability_kwargs)
         if _prob == 1.0:
             # this ensures we don't change rng for the tests, but its not really needed

--- a/neurots/utils.py
+++ b/neurots/utils.py
@@ -97,11 +97,11 @@ def point_to_section_segment(neuron, point, rtol=1e-05, atol=1e-08):
     raise ValueError(f"Cannot find point in morphology that matches: {point}")
 
 
-def accept_reject(propose, prob, rng, null=None, max_tries=100):
+def accept_reject(propose, prob, rng, null=None, max_tries=100, noise_increase=0.2):
     """Generic accept reject algorithm."""
     n_try = 0
     while n_try < max_tries:
-        proposal = propose()
+        proposal = propose(n_try * noise_increase)
         _prob = prob(proposal)
 
         if _prob == 1.0:

--- a/tests/test_orientations.py
+++ b/tests/test_orientations.py
@@ -517,12 +517,10 @@ def test_orientation_manager__apical_constraint():
         om.compute_tree_type_orientations(tree_type)
 
     with pytest.warns(UserWarning) as record:
-        tested._sample_trunk_from_3d_angle(
-            parameters, om._rng, "basal_dendrite", [0, 0, 1], max_tries=-1
-        )
+        om._sample_trunk_from_3d_angle("basal_dendrite", [0, 0, 1], max_tries=-1)
     assert len(record.list) == 1
     assert str(record.list[0].message).startswith(
-        "We could not sample from distribution, so we take a random point."
+        "We could not sample from distribution, we take best sample."
     )
 
     actual = om.get_tree_type_orientations("basal_dendrite")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -128,7 +128,7 @@ def test_accept_reject():
     def propose_null():
         return 0.0
 
-    # check if we attain max_tries we return null = 0
+    # check if we attain max_tries we return null = -1
     val = utils.accept_reject(propose_null, prob, rng, null=null)
     assert val == -1.0
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,19 +117,19 @@ def test_accept_reject():
             return 1.0
         return 0.0
 
-    def null():
+    def default_propose():
         return -1.0
 
     # check we always return 1
     for _ in range(10):
-        val = utils.accept_reject(propose, prob, rng, null=null)
+        val = utils.accept_reject(propose, prob, rng, default_propose=default_propose)
         assert val == 1.0
 
     def propose_null(_):
         return 0.0
 
-    # check if we attain max_tries we return null = -1
-    val = utils.accept_reject(propose_null, prob, rng, null=null)
+    # check if we attain max_tries we return default_propose = -1
+    val = utils.accept_reject(propose_null, prob, rng, default_propose=default_propose)
     assert val == -1.0
 
     # check if we attain max_tries we return random

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,3 +104,30 @@ def test_point_to_section_segment():
     section, segment = utils.point_to_section_segment(neuron, [0.0, 15.28, 0.0])
     assert section == 63
     assert segment == 0
+
+
+def test_accept_reject():
+    rng = np.random.default_rng(42)
+
+    def propose():
+        return rng.integers(0, 2)
+
+    def prob(proposal):
+        if proposal > 0.5:
+            return 1.0
+        return 0.0
+
+    def null():
+        return 0.0
+
+    # check we always return 1
+    for _ in range(10):
+        val = utils.accept_reject(propose, prob, rng, null=null)
+        assert val == 1.0
+
+    def propose():
+        return 0
+
+    # check if we attain max_tries we return null = 0
+    val = utils.accept_reject(propose, prob, rng, null=null)
+    assert val == 0.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -109,7 +109,7 @@ def test_point_to_section_segment():
 def test_accept_reject():
     rng = np.random.default_rng(42)
 
-    def propose():
+    def propose(_):
         return rng.integers(0, 2)
 
     def prob(proposal):
@@ -125,7 +125,7 @@ def test_accept_reject():
         val = utils.accept_reject(propose, prob, rng, null=null)
         assert val == 1.0
 
-    def propose_null():
+    def propose_null(_):
         return 0.0
 
     # check if we attain max_tries we return null = -1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,20 +117,17 @@ def test_accept_reject():
             return 1.0
         return 0.0
 
-    def default_propose():
-        return -1.0
-
     # check we always return 1
     for _ in range(10):
-        val = utils.accept_reject(propose, prob, rng, default_propose=default_propose)
+        val = utils.accept_reject(propose, prob, rng)
         assert val == 1.0
 
     def propose_null(_):
         return 0.0
 
-    # check if we attain max_tries we return default_propose = -1
-    val = utils.accept_reject(propose_null, prob, rng, default_propose=default_propose)
-    assert val == -1.0
+    # check if we attain max_tries we return best
+    val = utils.accept_reject(propose_null, prob, rng)
+    assert val == 0.0
 
     # check if we attain max_tries we return random
     val = utils.accept_reject(propose_null, prob, rng)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -118,7 +118,7 @@ def test_accept_reject():
         return 0.0
 
     def null():
-        return 0.0
+        return -1.0
 
     # check we always return 1
     for _ in range(10):
@@ -126,11 +126,11 @@ def test_accept_reject():
         assert val == 1.0
 
     def propose_null():
-        return 0
+        return 0.0
 
     # check if we attain max_tries we return null = 0
     val = utils.accept_reject(propose_null, prob, rng, null=null)
-    assert val == 0.0
+    assert val == -1.0
 
     # check if we attain max_tries we return random
     val = utils.accept_reject(propose_null, prob, rng)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,9 +125,9 @@ def test_accept_reject():
         val = utils.accept_reject(propose, prob, rng, null=null)
         assert val == 1.0
 
-    def propose():
+    def propose_null():
         return 0
 
     # check if we attain max_tries we return null = 0
-    val = utils.accept_reject(propose, prob, rng, null=null)
+    val = utils.accept_reject(propose_null, prob, rng, null=null)
     assert val == 0.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,3 +131,7 @@ def test_accept_reject():
     # check if we attain max_tries we return null = 0
     val = utils.accept_reject(propose_null, prob, rng, null=null)
     assert val == 0.0
+
+    # check if we attain max_tries we return random
+    val = utils.accept_reject(propose_null, prob, rng)
+    assert val == 0.0

--- a/tox.ini
+++ b/tox.ini
@@ -62,11 +62,7 @@ commands_pre =
     pip freeze
 
 [testenv:lint]
-<<<<<<< HEAD
 basepython = python3.9
-=======
-basepython = python3
->>>>>>> af3d21b (fix)
 deps =
     pre-commit
     pylint

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
     pylint -j {env:PYLINT_NPROCS:1} {[base]files}
 
 [testenv:format]
-basepython = python3.9
+basepython = python3
 skip_install = true
 deps =
     codespell

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,11 @@ commands_pre =
     pip freeze
 
 [testenv:lint]
+<<<<<<< HEAD
 basepython = python3.9
+=======
+basepython = python3
+>>>>>>> af3d21b (fix)
 deps =
     pre-commit
     pylint


### PR DESCRIPTION
This PR adds an accept/reject mechanisms to allow for external modification of section and trunk growths via the generic `context` object.