### PR TITLE
Fix: Relax soma/first point check

### DIFF
--- a/neurots/generate/soma.py
+++ b/neurots/generate/soma.py
@@ -87,7 +87,7 @@ class Soma:
 
     def orientation_from_point(self, point):
         """Return the orientation from the soma center to a point on the soma surface."""
-        if np.allclose(point, self.center, atol=0.01, rtol=0):
+        if np.allclose(point, self.center, rtol=0):
             raise ValueError("Point overlaps with soma center.")
 
         point = np.asarray([point])

--- a/neurots/generate/soma.py
+++ b/neurots/generate/soma.py
@@ -87,7 +87,7 @@ class Soma:
 
     def orientation_from_point(self, point):
         """Return the orientation from the soma center to a point on the soma surface."""
-        if np.allclose(point, self.center):
+        if np.allclose(point, self.center, atol=0.01, rtol=0):
             raise ValueError("Point overlaps with soma center.")
 
         point = np.asarray([point])


### PR DESCRIPTION
If one has a soma located far from origin, the rtol may consider the point to be too close, hence its better to only use atol.