### PR TITLE
Fix: Handle near symetrical two major apical branches

### DIFF
--- a/neurots/generate/algorithms/tmdgrower.py
+++ b/neurots/generate/algorithms/tmdgrower.py
@@ -245,7 +245,7 @@ class TMDApicalAlgo(TMDAlgo):
             self.apical_point_distance_from_soma = selected_length - 10 * step_size
         return stop, num_sec
 
-    def bifurcate(self, current_section):
+    def bifurcate(self, current_section, two_major=0):
         """When the section bifurcates two new sections need to be created.
 
         This method computes from the current state the data required for the
@@ -261,13 +261,19 @@ class TMDApicalAlgo(TMDAlgo):
 
         if current_section.process == "major":
             dir1, dir2 = bif_methods["directional"](current_section.direction, angles=ang)
+            if two_major:
+                dir2 = dir1 + np.array([0.5, 0, 0])
+                dir1 = dir1 - np.array([0.5, 0, 0])
 
             if not self._found_last_bif:
                 self.apical_section = current_section.id
 
             if current_pd <= self.apical_point_distance_from_soma:
                 process1 = "major"
-                process2 = "secondary"
+                if two_major:
+                    process2 = "major"
+                else:
+                    process2 = "secondary"
             else:
                 process1 = "secondary"
                 process2 = "secondary"

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -118,7 +118,7 @@ class SectionGrower:
         direction = self.params.targeting * self.direction + self.params.history * self.history()
 
         direction = direction / vectorial_norm(direction)
-        seg_length = self.step_size_distribution.draw_positive()
+        seg_length = 1.0  # self.step_size_distribution.draw_positive()
         point = self.last_point + seg_length * direction
         self.update_pathlength(seg_length)
 

--- a/neurots/generate/tree.py
+++ b/neurots/generate/tree.py
@@ -120,6 +120,7 @@ class TreeGrower:
         self.active_sections = []
         self.context = context
         self._rng = random_generator
+        self.two_major = 1  # local hack to have two major branches in first bif
 
         # Creates the distribution from which the segment lengths
         # To sample a new seg_len call self.seg_len.draw()
@@ -259,14 +260,17 @@ class TreeGrower:
                     section_grower.id = section.id
                     # the current section_grower bifurcates
                     # Returns two section_grower dictionaries: (S1, S2)
-                    for child_section in self.growth_algo.bifurcate(section_grower):
+                    for child_section in self.growth_algo.bifurcate(
+                        section_grower, two_major=self.two_major
+                    ):
+                        self.two_major = 0
                         child = self.add_section(
                             parent=section, pathlength=section_grower.pathlength, **child_section
                         )
                         # Copy the final normed direction of parent to all children
                         child.latest_directions.append(latest)
                         # Generate the first point of the section
-                        child.first_point()
+                        # child.first_point()
                     self.active_sections.remove(section_grower)
 
                 elif state == "terminate":


### PR DESCRIPTION
Some explanation:
- to fix the asymetrical issue, I realised that the pathlength of the two branches was not identical, and the one with bif was larger, hence it will get more bif than the other. 
- I first thought it was because of random seg_length, so I freeze to 1
- then I realised that it was also (or mostly) due to the fact that a .fist_point is called after a big, hence it had 1 micron to pathlength when a bif occurs, hence this branch is more likely to get the next bif
- I also tried a new argument to have 2 major branches, and control there angle, so it looks more like the hipp reconstructions