### PR TITLE
Feat: Add a uniform diameter model and deprecate the 'radius' parameter

### DIFF
--- a/neurots/generate/diametrizer.py
+++ b/neurots/generate/diametrizer.py
@@ -355,6 +355,24 @@ def diametrize_constant_per_neurite(neuron, neurite_type=None):
             sec.diameters = mean_diam * np.ones(len(sec.diameters))
 
 
+def diametrize_uniform(neuron, neurite_type=None, *, diam_params):
+    """Set all diameters of a morphio-neuron to a given value.
+
+    Args:
+        neuron (morphio.mut.Morphology): The morphology that will be diametrized.
+        neurite_type (morphio.SectionType): Only the neurites of this type are diametrized.
+        diam_params (dict): The model parameters (should only contain a 'diameter' entry).
+    """
+    diameter = diam_params.get(neurite_type.name, None)
+    if diameter is None:
+        return
+    roots = root_section_filter(neuron, neurite_type)
+
+    for root in roots:
+        for sec in root.iter():
+            sec.diameters = diameter * np.ones(len(sec.diameters))
+
+
 def diametrize_smoothing(neuron, neurite_type=None):
     """Corrects the diameters of a morphio-neuron, by smoothing them within each section.
 
@@ -367,6 +385,7 @@ def diametrize_smoothing(neuron, neurite_type=None):
 
 
 diam_methods = {
+    "uniform": diametrize_uniform,
     "M1": diametrize_constant_per_neurite,
     "M2": diametrize_constant_per_section,
     "M3": diametrize_smoothing,

--- a/neurots/generate/tree.py
+++ b/neurots/generate/tree.py
@@ -223,7 +223,7 @@ class TreeGrower:
             data = {
                 "parent": section.parent.id if section.parent else None,
                 "coord": np.vstack(section.points).tolist(),
-                "radius": [self.params["radius"] * 2] * len(section.points),
+                "radius": [0.5] * len(section.points),
                 "type": int(SectionType(self.params["tree_type"])),
             }
             L.debug("appended_data=%s", json.dumps(data))
@@ -231,7 +231,7 @@ class TreeGrower:
         return append_fun(
             PointLevel(
                 np.array(section.points).tolist(),
-                [self.params["radius"] * 2] * len(section.points),
+                [1] * len(section.points),
             ),
             SectionType(self.params["tree_type"]),
         )

--- a/neurots/generate/tree.py
+++ b/neurots/generate/tree.py
@@ -223,7 +223,6 @@ class TreeGrower:
             data = {
                 "parent": section.parent.id if section.parent else None,
                 "coord": np.vstack(section.points).tolist(),
-                "radius": [0.5] * len(section.points),
                 "type": int(SectionType(self.params["tree_type"])),
             }
             L.debug("appended_data=%s", json.dumps(data))

--- a/neurots/generate/tree.py
+++ b/neurots/generate/tree.py
@@ -34,8 +34,11 @@ from neurots.utils import NeuroTSError
 
 L = logging.getLogger("neurots")
 
-# LAMBDA: parameter that defines the slope of exponential probability
 LAMBDA = 1.0
+"""Parameter that defines the slope of exponential probability."""
+
+DEFAULT_DIAMETER = 1
+"""The default diameter used to add new sections before they are diametrized later."""
 
 growth_algorithms = {
     "tmd": tmdgrower.TMDAlgo,
@@ -230,7 +233,7 @@ class TreeGrower:
         return append_fun(
             PointLevel(
                 np.array(section.points).tolist(),
-                [1] * len(section.points),
+                [DEFAULT_DIAMETER] * len(section.points),
             ),
             SectionType(self.params["tree_type"]),
         )

--- a/neurots/preprocess/validity_checkers.py
+++ b/neurots/preprocess/validity_checkers.py
@@ -99,13 +99,15 @@ def check_diameter_consistency(params, distrs):
 
 
 @register_global_validator()
-def check_deprecated_radius(params, distrs):
+def check_deprecated_radius(params, distrs):  # pylint: disable=unused-argument
+    """Check that the 'radius' parameter is not present or raise a warning."""
     grow_types = params.get("grow_types", [])
     for i in grow_types:
         neurite_type_params = params.get(i, {})
         if "radius" in neurite_type_params:
             warnings.warn(
                 f"The 'radius' parameter (in {i}) is deprecated and will be forbidden in a future "
-                "version",
+                "version, most of the time it's not used but if you want to retrieve the same "
+                "results as before please use the 'uniform' diameter model.",
                 FutureWarning,
             )

--- a/neurots/preprocess/validity_checkers.py
+++ b/neurots/preprocess/validity_checkers.py
@@ -24,6 +24,8 @@ The checkers should be registered to be executed in the preprocess step using th
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import warnings
+
 from neurots.preprocess.exceptions import NeuroTSValidationError
 from neurots.preprocess.relevance_checkers import check_min_bar_length
 from neurots.preprocess.utils import register_global_validator
@@ -94,3 +96,16 @@ def check_diameter_consistency(params, distrs):
             "Diameters methods of parameters and distributions is inconsistent:"
             + f" {method1} != {method2}"
         )
+
+
+@register_global_validator()
+def check_deprecated_radius(params, distrs):
+    grow_types = params.get("grow_types", [])
+    for i in grow_types:
+        neurite_type_params = params.get(i, {})
+        if "radius" in neurite_type_params:
+            warnings.warn(
+                f"The 'radius' parameter (in {i}) is deprecated and will be forbidden in a future "
+                "version",
+                FutureWarning,
+            )

--- a/neurots/schemas/parameters.json
+++ b/neurots/schemas/parameters.json
@@ -319,7 +319,7 @@
                     "properties": {
                         "method": {
                             "enum": [
-                                "external", "default"
+                                "external", "default", "uniform"
                             ],
                             "description": "The method used to synthesize the diameters",
                             "type": "string"
@@ -333,7 +333,7 @@
                             "description": "The method used to synthesize the diameters",
                             "not": {
                                 "enum": [
-                                    "external", "default"
+                                    "external", "default", "uniform"
                                 ]
                             },
                             "type": "string"

--- a/neurots/schemas/parameters.json
+++ b/neurots/schemas/parameters.json
@@ -252,7 +252,6 @@
                 "metric",
                 "modify",
                 "orientation",
-                "radius",
                 "randomness",
                 "targeting",
                 "tree_type"

--- a/tests/astrocyte/data/bio_path_distribution.json
+++ b/tests/astrocyte/data/bio_path_distribution.json
@@ -419,5 +419,5 @@
             }
         }
     },
-"diameter": {"method": "default"}
+"diameter": {"method": "uniform"}
 }

--- a/tests/astrocyte/data/bio_path_params.json
+++ b/tests/astrocyte/data/bio_path_params.json
@@ -24,4 +24,7 @@
 "apical": {},
 "origin": [0.0, 0.0, 0.0],
 "grow_types": ["basal", "axon"],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/astrocyte/test_grower.py
+++ b/tests/astrocyte/test_grower.py
@@ -34,7 +34,6 @@ def _parameters():
             "metric": "path_distances",
             "randomness": 0.0,
             "targeting": 0.2,
-            "radius": 0.3,
             "orientation": None,
             "growth_method": "tmd_space_colonization",
             "branching_method": "bio_oriented",
@@ -48,7 +47,6 @@ def _parameters():
             "metric": "path_distances",
             "randomness": 0.0,
             "targeting": 0.2,
-            "radius": 0.3,
             "target_ids": [0, 1],
             "growth_method": "tmd_space_colonization_target",
             "branching_method": "bio_oriented",
@@ -63,7 +61,6 @@ def _parameters():
             "metric": "path_distances",
             "randomness": 0.0,
             "targeting": 0.2,
-            "radius": 0.3,
             "orientation": [[1.0, 0.0, 0.0], [0.1, 0.1, 0.1]],
             "growth_method": "tmd_space_colonization",
             "branching_method": "bio_oriented",
@@ -75,7 +72,12 @@ def _parameters():
         },
         "origin": [0.0, 0.0, 0.0],
         "grow_types": ["basal", "axon", "apical"],
-        "diameter_params": {"method": "default"},
+        "diameter_params": {
+            "method": "uniform",
+            "basal_dendrite": 0.6,
+            "apical_dendrite": 0.6,
+            "axon": 0.6,
+        },
     }
 
 

--- a/tests/data/axon_trunk_distribution.json
+++ b/tests/data/axon_trunk_distribution.json
@@ -109,6 +109,6 @@
         }
     },
     "diameter": {
-        "method": "default"
+        "method": "uniform"
     }
 }

--- a/tests/data/axon_trunk_parameters.json
+++ b/tests/data/axon_trunk_parameters.json
@@ -1,7 +1,6 @@
 {"axon": {"randomness": 0.0,
            "metric": "trunk_length",
            "targeting": 0.2,
-           "radius": 0.3,
            "num_seg": 999,
            "orientation": [[0.0,
                             1.0,
@@ -15,4 +14,6 @@
            0.0,
            0.0],
 "grow_types": ["axon"],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "axon": 0.6
+}}

--- a/tests/data/axon_trunk_parameters_absolute.json
+++ b/tests/data/axon_trunk_parameters_absolute.json
@@ -1,7 +1,6 @@
 {"axon": {"randomness": 0.0,
            "metric": "trunk_length",
            "targeting": 0.2,
-           "radius": 0.3,
            "num_seg": 999,
            "orientation": [[0.0,
                             1.0,
@@ -17,4 +16,5 @@
            0.0,
            0.0],
 "grow_types": ["axon"],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "axon": 0.6}}

--- a/tests/data/axon_trunk_parameters_absolute_orientation_manager.json
+++ b/tests/data/axon_trunk_parameters_absolute_orientation_manager.json
@@ -1,7 +1,6 @@
 {"axon": {"randomness": 0.0,
            "metric": "trunk_length",
            "targeting": 0.2,
-           "radius": 0.3,
            "num_seg": 999,
            "orientation": {
                "mode": "sample_around_primary_orientation",
@@ -19,4 +18,5 @@
            0.0,
            0.0],
 "grow_types": ["axon"],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "axon": 0.6}}

--- a/tests/data/axon_trunk_parameters_orientation_manager.json
+++ b/tests/data/axon_trunk_parameters_orientation_manager.json
@@ -1,7 +1,6 @@
 {"axon": {"randomness": 0.0,
            "metric": "trunk_length",
            "targeting": 0.2,
-           "radius": 0.3,
            "num_seg": 999,
            "orientation": {
                "mode": "use_predefined",
@@ -18,4 +17,5 @@
            0.0,
            0.0],
 "grow_types": ["axon"],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "axon": 0.6}}

--- a/tests/data/bio_distribution.json
+++ b/tests/data/bio_distribution.json
@@ -771,6 +771,6 @@
         }
     },
     "diameter": {
-        "method": "default"
+        "method": "uniform"
     }
 }

--- a/tests/data/bio_distribution_3d_angles.json
+++ b/tests/data/bio_distribution_3d_angles.json
@@ -34940,7 +34940,7 @@
         }
     },
     "diameter": {
-        "method": "default"
+        "method": "uniform"
     },
     "soma": {
         "size": {

--- a/tests/data/bio_distribution_apical_point.json
+++ b/tests/data/bio_distribution_apical_point.json
@@ -173,6 +173,6 @@
         }
     },
     "diameter": {
-        "method": "default"
+        "method": "uniform"
     }
 }

--- a/tests/data/bio_gradient_path_params.json
+++ b/tests/data/bio_gradient_path_params.json
@@ -29,4 +29,7 @@
            0.0,
            0.0],
 "grow_types": ["basal_dendrite","apical_dendrite"],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/data/bio_gradient_path_params_orientation_manager.json
+++ b/tests/data/bio_gradient_path_params_orientation_manager.json
@@ -34,4 +34,7 @@
            0.0,
            0.0],
 "grow_types": ["basal_dendrite","apical_dendrite"],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/data/bio_parameters_3d_angles.json
+++ b/tests/data/bio_parameters_3d_angles.json
@@ -52,8 +52,10 @@
         "targeting": 0.16,
         "tree_type": 3
     },
-    "diameter_params": {
-        "method": "default"
+    "diameter_params": {"method": "uniform",
+                        "basal_dendrite": 0.6,
+                        "apical_dendrite": 0.6,
+                        "axon": 0.6
     },
     "grow_types": [
         "apical_dendrite",

--- a/tests/data/bio_path_distribution.json
+++ b/tests/data/bio_path_distribution.json
@@ -373,6 +373,6 @@
         }
     },
     "diameter": {
-        "method": "default"
+        "method": "uniform"
     }
 }

--- a/tests/data/bio_path_params.json
+++ b/tests/data/bio_path_params.json
@@ -27,4 +27,7 @@
            0.0,
            0.0],
 "grow_types": ["basal_dendrite", "apical_dendrite"],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/data/bio_path_params_orientation_manager.json
+++ b/tests/data/bio_path_params_orientation_manager.json
@@ -24,4 +24,7 @@
            0.0,
            0.0],
 "grow_types": ["basal_dendrite", "apical_dendrite"],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/data/bio_rat_L5_TPC_B_distribution.json
+++ b/tests/data/bio_rat_L5_TPC_B_distribution.json
@@ -4095,6 +4095,6 @@
         }
     },
     "diameter": {
-        "method": "default"
+        "method": "uniform"
     }
 }

--- a/tests/data/bio_trunk_distribution.json
+++ b/tests/data/bio_trunk_distribution.json
@@ -101,6 +101,6 @@
         }
     },
     "diameter": {
-        "method": "default"
+        "method": "uniform"
     }
 }

--- a/tests/data/params1.json
+++ b/tests/data/params1.json
@@ -26,4 +26,7 @@
 "origin": [0.0,
            0.0,
            0.0],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/data/params1_orientation_manager.json
+++ b/tests/data/params1_orientation_manager.json
@@ -24,4 +24,7 @@
 "origin": [0.0,
            0.0,
            0.0],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/data/params2.json
+++ b/tests/data/params2.json
@@ -26,4 +26,7 @@
 "origin": [0.0,
            0.0,
            0.0],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/data/params2_orientation_manager.json
+++ b/tests/data/params2_orientation_manager.json
@@ -24,4 +24,8 @@
 "origin": [0.0,
            0.0,
            0.0],
-"diameter_params": {"method": "default"}}
+"diameter_params": {
+                    "method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/data/params3.json
+++ b/tests/data/params3.json
@@ -28,4 +28,7 @@
 "origin": [0.0,
            0.0,
            0.0],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/data/params3_orientation_manager.json
+++ b/tests/data/params3_orientation_manager.json
@@ -28,4 +28,7 @@
 "origin": [0.0,
            0.0,
            0.0],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/data/params4.json
+++ b/tests/data/params4.json
@@ -26,4 +26,7 @@
 "origin": [0.0,
            0.0,
            0.0],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/data/params4_orientation_manager.json
+++ b/tests/data/params4_orientation_manager.json
@@ -30,4 +30,7 @@
 "origin": [0.0,
            0.0,
            0.0],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/data/trunk_parameters.json
+++ b/tests/data/trunk_parameters.json
@@ -13,4 +13,7 @@
            0.0,
            0.0],
 "grow_types": ["basal_dendrite"],
-"diameter_params": {"method": "default"}}
+"diameter_params": {"method": "uniform",
+                    "basal_dendrite": 0.6,
+                    "apical_dendrite": 0.6,
+                    "axon": 0.6}}

--- a/tests/test_diametrizer.py
+++ b/tests/test_diametrizer.py
@@ -425,7 +425,7 @@ def test_build_unknown_model(neu1):
         KeyError,
         match=(
             "The name of the diametrization method is unknown: 'UNKNOWN' is not in "
-            r"\['M1', 'M2', 'M3', 'M4', 'M5'\]"
+            r"\['uniform', 'M1', 'M2', 'M3', 'M4', 'M5'\]"
         ),
     ):
         diametrizer.build(neu1, None, None, "UNKNOWN")

--- a/tests/test_neuron_functional.py
+++ b/tests/test_neuron_functional.py
@@ -189,8 +189,8 @@ def test_external_diametrizer():
         os.path.join(_path, "bio_path_distribution.json"),
         os.path.join(_path, "bio_path_params.json"),
     )
-    distributions["diameter"]["method"] = "M1"
-    parameters["diameter_params"]["method"] = "M1"
+    distributions["diameter"] = {"method": "M1"}
+    parameters["diameter_params"] = {"method": "M1"}
     ng = NeuronGrower(parameters, distributions, rng_or_seed=0)
     ng.grow()
 
@@ -233,8 +233,8 @@ def test_convert_orientation2points():
         os.path.join(_path, "bio_path_distribution.json"),
         os.path.join(_path, "bio_path_params.json"),
     )
-    distributions["diameter"]["method"] = "M1"
-    parameters["diameter_params"]["method"] = "M1"
+    distributions["diameter"] = {"method": "M1"}
+    parameters["diameter_params"] = {"method": "M1"}
     ng = NeuronGrower(parameters, distributions)
 
     pts = ng._convert_orientation2points([[0, 1, 0]], 1, distributions["apical_dendrite"], {})


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
<!-- The title should have the following form: 'Type: Subject' with 'type' in [Build,Chore,CI,Reprecate,Docs,Feat,Fix,Perf,Refactor,Revert,Style,Test] -->

### Description
The 'radius' parameter is used as default diameter value when we add sections but it's supposed to overwritten by the `NeuronGrower._diametrize` method, so we can just use an internal default value. Nevertheless, in some specific cases the diametrizer does nothing (that's actually the case in many tests), which I think is a bit weird. But to reproduce this behavior if someone needs it I added a `uniform` model which can take a diameter value and apply it to the entire neurites.

### Checklist
<!-- Go over following points. Check them with an `x` if they do apply (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once). -->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- [ ] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the issue).
	- [ ] Please include tests that fail with the `main` branch and pass with the provided fix.
- [x] A new feature implementation or update an existing feature
	- [ ] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the feature).
	- [x] Please include tests that cover every lines of the new/updated feature.
	- [ ] Please update the documentation to describe the new/updated feature.

<!-- **Have a nice day!** -->
