### PR TITLE
Fix: Ensure growth in a section is not biased by parent direction

### DIFF
--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -115,7 +115,7 @@ class SectionGrower:
             The growth process cannot terminate before this point, as a first point will always be
             added to an active section.
         """
-        direction = self.params.targeting * self.direction
+        direction = self.params.targeting * self.direction + self.params.history * self.history()
 
         direction = direction / vectorial_norm(direction)
         seg_length = self.step_size_distribution.draw_positive()

--- a/neurots/generate/section.py
+++ b/neurots/generate/section.py
@@ -115,7 +115,7 @@ class SectionGrower:
             The growth process cannot terminate before this point, as a first point will always be
             added to an active section.
         """
-        direction = self.params.targeting * self.direction + self.params.history * self.history()
+        direction = self.params.targeting * self.direction
 
         direction = direction / vectorial_norm(direction)
         seg_length = self.step_size_distribution.draw_positive()

--- a/neurots/generate/tree.py
+++ b/neurots/generate/tree.py
@@ -285,7 +285,6 @@ class TreeGrower:
                             parent=section, pathlength=section_grower.pathlength, **child_section
                         )
                         # Copy the final normed direction of parent to all children
-                        child.latest_directions.append(latest)
                         # Generate the first point of the section
                         child.first_point()
                     self.active_sections.remove(section_grower)


### PR DESCRIPTION
If we use the direction of the parent, then without noise, we'll make a consistent 'turn' toward the direction of the parent, if the angle at the bif is large. I think this is not so 'nice'.

Here is an example of a synthesized cell with randomness=0 with this PR: 
![Screenshot 2023-11-27 at 13 56 50](https://github.com/BlueBrain/NeuroTS/assets/12429955/7d710c4e-8385-4158-9c69-3e8a59c5f232)

and without:
![Screenshot 2023-11-27 at 13 58 14](https://github.com/BlueBrain/NeuroTS/assets/12429955/f3dbbc45-cbf1-4a85-913d-1d5f32037c33)
